### PR TITLE
Use `pyproject.toml` file for specifying project metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include requirements.txt
+include version.txt

--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ Type error in return value:
     Expected type 'int64' for column B' but found type 'int32'
     Missing column in DataFrame: 'C'
 ```
+
+References
+----------
+
+* [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+* [Python Packaging User Guide](https://packaging.python.org/en/latest/)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ name = "pandas-type-checks"
 description = "Structural type checking for Pandas data frames."
 readme = "README.md"
 authors = [{ name = "Martin Zuber", email = "martin.zuber@sap.com" }]
-maintainers = [{ name = "Martin Zuber", email = "martin.zuber@sap.com" }]
-license = { file = "LICENSE" }
+license = { text = "BSD 3-Clause License" }
 keywords = ["Pandas", "type check"]
 classifiers = [
     # complete classifier list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
     'Development Status :: 3 - Alpha',
-    'Intended Audience :: Developer',
+    'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=61.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pandas-type-checks"
+description = "Structural type checking for Pandas data frames."
+readme = "README.md"
+authors = [{ name = "Martin Zuber", email = "martin.zuber@sap.com" }]
+maintainers = [{ name = "Martin Zuber", email = "martin.zuber@sap.com" }]
+license = { file = "LICENSE" }
+keywords = ["Pandas", "type check"]
+classifiers = [
+    # complete classifier list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Developer',
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Topic :: Scientific/Engineering',
+    'Topic :: Software Development :: Libraries',
+    'Typing :: Typed'
+]
+
+requires-python=">=3.6"
+dynamic = ["version", "dependencies"]
+
+[project.urls]
+"Source Code" = "https://github.com/mzuber/pandas-type-checks"
+
+[tool.setuptools]
+platforms = ["any"]
+
+[tool.setuptools.dynamic]
+version = {file = "version.txt"}
+dependencies = {file = "requirements.txt"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,5 @@
 #!/usr/bin/env python
 
-import os
+from setuptools import setup
 
-from setuptools import setup, find_packages
-
-with open('requirements.txt') as requirements_file:
-    requirements = requirements_file.read().splitlines()
-
-with open(os.path.join(os.path.dirname(__file__), 'version.txt')) as version_file:
-    version = version_file.read().strip()
-
-setup(
-    name='pandas-type-checks',
-    version=version,
-    author='Martin Zuber',
-    author_email='martin.zuber@sap.com',
-    description='Structural type checking for Pandas data frames.',
-    license='BSD',
-    keywords=[
-        'Pandas', 'type check'
-    ],
-    url='https://github.com/mzuber/pandas-type-checks',
-    project_urls={
-        'Source Code': 'https://github.com/mzuber/pandas-type-checks',
-    },
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    platforms='any',
-    install_requires=requirements,
-    python_requires='>=3.6',
-    include_package_data=True,
-    classifiers=[
-        # complete classifier list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developer',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development :: Libraries',
-        'Typing :: Typed'
-    ]
-)
+setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-skipsdist = False
-skip_install = True
+skipsdist = True
 
 [flake8]
 count = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-skipsdist = True
+skipsdist = False
 
 [flake8]
 count = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 skipsdist = False
+skip_install = True
 
 [flake8]
 count = False


### PR DESCRIPTION
Changes:
* Use `pyproject.toml` instead of `setup.py` file for specifying project metadata
* Enable packaging of library in `tox` run