### PR TITLE
Support logging type errors instead of raising exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ filter_rows_and_remove_column(test_data, test_filter_values_with_wrong_type)
 ```
 
 ```
-TypeError: Pandas type error
+TypeError: Pandas type error in function 'filter_rows_and_remove_column'
 Type error in argument 'filter_values':
 	Expected Series of type 'int64' but found type 'int32'
 ```
@@ -68,7 +68,7 @@ filter_rows_and_remove_column(test_data_with_wrong_type_and_missing_column, test
 ```
 
 ```
-TypeError: Pandas type error
+TypeError: Pandas type error in function 'filter_rows_and_remove_column'
 Type error in argument 'data':
     Expected type 'int64' for column B' but found type 'int32'
     Missing column in DataFrame: 'C'

--- a/src/pandas_type_checks/core.py
+++ b/src/pandas_type_checks/core.py
@@ -1,9 +1,13 @@
 from typing import Dict, Any, Union, Optional, List, Type
+import logging
 
 import pandas as pd
 import numpy as np
 
 from pandas.core.dtypes.base import ExtensionDtype
+
+
+default_logger = logging.getLogger('pandas_type_checks')
 
 
 class PandasTypeCheckConfiguration(object):
@@ -18,12 +22,19 @@ class PandasTypeCheckConfiguration(object):
             If strict type checking is enabled data frames cannot contain columns which are not part of the type
             specification against which they are checked. Non-strict type checking in that sense allows a form of
             structural subtyping for data frames.
+        log_type_errors (bool): Flag indicating that type errors for Pandas dataframes or series values should be
+            logged instead of raising a 'TypeError' exception.
+        logger (logging.Logger): Logger to be used for logging type errors when 'log_type_errors' flag is enabled.
     """
 
     def __init__(self, enable_type_checks: bool = True,
-                 strict_type_checks: bool = False):
+                 strict_type_checks: bool = False,
+                 log_type_errors: bool = False,
+                 logger: logging.Logger = default_logger):
         self.enable_type_checks = enable_type_checks
         self.strict_type_checks = strict_type_checks
+        self.log_type_errors = log_type_errors
+        self.logger = logger
 
 
 config = PandasTypeCheckConfiguration()

--- a/src/pandas_type_checks/util.py
+++ b/src/pandas_type_checks/util.py
@@ -3,12 +3,14 @@ from typing import List, Dict
 from pandas_type_checks.core import PandasTypeCheckError
 
 
-def build_exception_message(arg_type_check_errors: Dict[str, List[PandasTypeCheckError]],
+def build_exception_message(func_name: str,
+                            arg_type_check_errors: Dict[str, List[PandasTypeCheckError]],
                             ret_value_type_check_errors: List[PandasTypeCheckError]) -> str:
     """
     Build a formatted error message for all the given type check errors.
 
     Args:
+        func_name: Name of the function in which the typer errors occurred
         arg_type_check_errors: Dictionary containing the type check errors found for all
           arguments of an annotated function
         ret_value_type_check_errors: list containing the type check errors found for the
@@ -17,7 +19,7 @@ def build_exception_message(arg_type_check_errors: Dict[str, List[PandasTypeChec
     Returns:
         A formatted string with the full error message containing all given type check errors
     """
-    exec_msg: List[str] = ["Pandas type error"]
+    exec_msg: List[str] = [f"Pandas type error in function '{func_name}'"]
 
     # Add argument type check errors to exception message
     for arg_name, type_check_errors in arg_type_check_errors.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,9 @@ def before_all():
     # Use non-strict type checking mode as default for each test
     pandas_type_checks_config.strict_type_checks = False
 
+    # Raise exceptions for type errors as default for each test
+    pandas_type_checks_config.log_type_errors = False
+
     yield  # run test function
 
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -9,6 +9,8 @@ from pandas_type_checks.decorator import pandas_type_check, PandasTypeCheckDecor
 def test_data_frame_argument(data_frame, data_frame_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameArgument('arg', data_frame_type))
     def test_function(arg: pd.DataFrame) -> pd.DataFrame:
@@ -21,6 +23,8 @@ def test_data_frame_argument(data_frame, data_frame_type):
 def test_data_frame_return_value(data_frame, data_frame_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameReturnValue(data_frame_type))
     def test_function() -> pd.DataFrame:
@@ -33,6 +37,8 @@ def test_data_frame_return_value(data_frame, data_frame_type):
 def test_series_argument(series, series_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(SeriesArgument('arg', series_type))
     def test_function(arg: pd.Series) -> pd.Series:
@@ -45,6 +51,8 @@ def test_series_argument(series, series_type):
 def test_series_return_value(series, series_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(SeriesReturnValue(series_type))
     def test_function() -> pd.Series:
@@ -57,53 +65,61 @@ def test_series_return_value(series, series_type):
 def test_type_error_for_data_frame_argument(data_frame_type, wrong_data_frame):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameArgument('arg', data_frame_type))
     def test_function(arg: pd.DataFrame) -> pd.DataFrame:
         return arg
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in argument 'arg':\n"
-                             "\tExpected type 'float64' for column A' but found type 'int64'\n"
-                             "\tMissing column in DataFrame: 'B'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in argument 'arg':\n"
+                             f"\tExpected type 'float64' for column A' but found type 'int64'\n"
+                             f"\tMissing column in DataFrame: 'B'"):
         test_function(wrong_data_frame)
 
 
 def test_type_error_for_data_frame_return_value(data_frame_type, wrong_data_frame):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameReturnValue(data_frame_type))
     def test_function() -> pd.DataFrame:
         return wrong_data_frame
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in return value:\n"
-                             "\tExpected type 'float64' for column A' but found type 'int64'\n"
-                             "\tMissing column in DataFrame: 'B'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in return value:\n"
+                             f"\tExpected type 'float64' for column A' but found type 'int64'\n"
+                             f"\tMissing column in DataFrame: 'B'"):
         test_function()
 
 
 def test_strict_type_check_for_data_frame_argument(data_frame_type, extended_data_frame):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameArgument('arg', data_frame_type), strict=True)
     def test_function(arg: pd.DataFrame) -> pd.DataFrame:
         return arg
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in argument 'arg':\n"
-                             "\tFound unspecified column in data frame: 'D'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in argument 'arg':\n"
+                             f"\tFound unspecified column in data frame: 'D'"):
         test_function(extended_data_frame)
 
 
 def test_strict_type_check_for_data_frame_return_value(data_frame_type, extended_data_frame):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     # Enable strict type check mode through keyword argument
     @pandas_type_check(DataFrameReturnValue(data_frame_type), strict=True)
@@ -111,45 +127,51 @@ def test_strict_type_check_for_data_frame_return_value(data_frame_type, extended
         return extended_data_frame
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in return value:\n"
-                             "\tFound unspecified column in data frame: 'D'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in return value:\n"
+                             f"\tFound unspecified column in data frame: 'D'"):
         test_function()
 
 
 def test_type_error_for_series_argument(series_type, wrong_series):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(SeriesArgument('arg', series_type))
     def test_function(arg: pd.Series) -> pd.Series:
         return arg
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in argument 'arg':\n"
-                             "\tExpected Series of type 'int64' but found type 'float64'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in argument 'arg':\n"
+                             f"\tExpected Series of type 'int64' but found type 'float64'"):
         test_function(wrong_series)
 
 
 def test_type_error_for_series_return_value(series_type, wrong_series):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(SeriesReturnValue(series_type))
     def test_function() -> pd.Series:
         return wrong_series
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in return value:\n"
-                             "\tExpected Series of type 'int64' but found type 'float64'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in return value:\n"
+                             f"\tExpected Series of type 'int64' but found type 'float64'"):
         test_function()
 
 
 def test_data_frame_argument_type_mismatch(data_frame_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameArgument('arg', data_frame_type))
     def test_function(arg: str) -> str:
@@ -165,6 +187,8 @@ def test_data_frame_argument_type_mismatch(data_frame_type):
 def test_series_argument_type_mismatch(series_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(SeriesArgument('arg', series_type))
     def test_function(arg: str) -> str:
@@ -180,6 +204,8 @@ def test_series_argument_type_mismatch(series_type):
 def test_return_value_type_mismatch(data_frame_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     return_value = 0
 
@@ -197,6 +223,8 @@ def test_return_value_type_mismatch(data_frame_type):
 def test_unknown_argument(data_frame_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     # Decorated function has no arguments
     @pandas_type_check(DataFrameArgument('arg', data_frame_type))
@@ -220,6 +248,8 @@ def test_unknown_argument(data_frame_type):
 def test_unsupported_decorator_argument():
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check("Unsupported String Argument")
     def test_function() -> int:
@@ -236,6 +266,8 @@ def test_unsupported_decorator_argument():
 def test_multiple_return_value_decorator_arguments(series, series_type, data_frame_type):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(SeriesReturnValue(series_type), DataFrameReturnValue(data_frame_type))
     def test_function() -> pd.Series:
@@ -249,6 +281,8 @@ def test_multiple_return_value_decorator_arguments(series, series_type, data_fra
 def test_disable_type_checks_through_config(data_frame_type, wrong_data_frame):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameArgument('arg', data_frame_type))
     def test_function(arg: pd.DataFrame) -> pd.DataFrame:
@@ -266,6 +300,8 @@ def test_disable_type_checks_through_config(data_frame_type, wrong_data_frame):
 def test_strict_type_check_mode_through_config(data_frame_type, extended_data_frame):
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(DataFrameReturnValue(data_frame_type))
     def test_function() -> pd.DataFrame:
@@ -275,7 +311,35 @@ def test_strict_type_check_mode_through_config(data_frame_type, extended_data_fr
     assert config.strict_type_checks is True
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in return value:\n"
-                             "\tFound unspecified column in data frame: 'D'"):
+                       match=f"Pandas type error in function '{test_function.__name__}'\n"
+                             f"Type error in return value:\n"
+                             f"\tFound unspecified column in data frame: 'D'"):
         test_function()
+
+
+def test_log_type_errors_through_config(data_frame_type, wrong_data_frame, caplog):
+    assert config.enable_type_checks is True
+    assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
+
+    @pandas_type_check(DataFrameArgument('arg', data_frame_type))
+    def test_function(arg: pd.DataFrame) -> pd.DataFrame:
+        return arg
+
+    # Disable type checks in global configuration
+    config.log_type_errors = True
+    assert config.log_type_errors is True
+
+    # No type error should be raised when applying the function to a data frame with the wrong structure
+    result = test_function(wrong_data_frame)
+    pd.testing.assert_frame_equal(result, wrong_data_frame)
+
+    # Instead the type error should be logged
+    assert caplog.records
+    log_record = caplog.records[-1]
+    assert log_record.levelname == 'ERROR'
+    assert log_record.message == (f"Pandas type error in function '{test_function.__name__}'\n"
+                                  f"Type error in argument 'arg':\n"
+                                  f"\tExpected type 'float64' for column A' but found type 'int64'\n"
+                                  f"\tMissing column in DataFrame: 'B'")

--- a/tests/test_usage_examples.py
+++ b/tests/test_usage_examples.py
@@ -10,6 +10,8 @@ from pandas_type_checks.decorator import pandas_type_check
 def test_usage_example():
     assert config.enable_type_checks is True
     assert config.strict_type_checks is False
+    assert config.log_type_errors is False
+    assert config.logger is not None
 
     @pandas_type_check(
         DataFrameArgument('data', {
@@ -42,9 +44,9 @@ def test_usage_example():
     test_filter_values_with_wrong_type = pd.Series([3, 4], dtype='int32')
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in argument 'filter_values':\n"
-                             "\tExpected Series of type 'int64' but found type 'int32'"):
+                       match=f"Pandas type error in function '{filter_rows_and_remove_column.__name__}'\n"
+                             f"Type error in argument 'filter_values':\n"
+                             f"\tExpected Series of type 'int64' but found type 'int32'"):
         filter_rows_and_remove_column(test_data, test_filter_values_with_wrong_type)
 
     # Apply function to data frame with wrong type and missing column
@@ -54,11 +56,11 @@ def test_usage_example():
     })
 
     with pytest.raises(TypeError,
-                       match="Pandas type error\n"
-                             "Type error in argument 'data':\n"
-                             "\tExpected type 'int64' for column B' but found type 'int32'\n"
-                             "\tMissing column in DataFrame: 'C'\n"
-                             "Type error in return value:\n"
-                             "\tExpected type 'int64' for column B' but found type 'int32'\n"
-                             "\tMissing column in DataFrame: 'C'"):
+                       match=f"Pandas type error in function '{filter_rows_and_remove_column.__name__}'\n"
+                             f"Type error in argument 'data':\n"
+                             f"\tExpected type 'int64' for column B' but found type 'int32'\n"
+                             f"\tMissing column in DataFrame: 'C'\n"
+                             f"Type error in return value:\n"
+                             f"\tExpected type 'int64' for column B' but found type 'int32'\n"
+                             f"\tMissing column in DataFrame: 'C'"):
         filter_rows_and_remove_column(test_data_with_wrong_type_and_missing_column, test_filter_values)


### PR DESCRIPTION
Added support to log type errors instead of raising exceptions.

This pull request introcudes a new configuraiton flag `log_type_errors` which when enabled will lead to type errors for Pandas values being logged instead of raising a `TypeError` exception.