### PR TITLE
Adapt Pandera error transformation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,6 @@ jobs:
   - job: Build
     strategy:
       matrix:
-        Python38:
-          python.version: '3.8'
-        Python39:
-          python.version: '3.9'
         Python310:
           python.version: '3.10'
         Python311:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/src/pandas_type_checks/pandera_support.py
+++ b/src/pandas_type_checks/pandera_support.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pandera.errors import SchemaErrors
+from pandera.errors import SchemaErrors, SchemaErrorReason
 
 from pandas_type_checks.errors import PandasTypeCheckError
 
@@ -21,7 +21,9 @@ def pandera_schema_errors_to_type_check_errors(schema_errors: SchemaErrors) -> L
         # Check if error relates to a specific column
         column_name: Optional[str] = None
         if schema_error.failure_cases is not None:
-            column_name = schema_error.schema.name if schema_error == "schema_component_check" else None
+            match schema_error.reason_code:
+                case SchemaErrorReason.DATAFRAME_CHECK | SchemaErrorReason.WRONG_DATATYPE:
+                    column_name = schema_error.schema.name
 
         type_check_error = PandasTypeCheckError(error_msg=str(schema_error), column_name=column_name)
         type_check_errors.append(type_check_error)


### PR DESCRIPTION
Adapt transformation of Pandera-internal error structure into `PandasTypeCheckError`s to reflect recent versions of the Pandera library.

Drop support for Python 3.8 and 3.9, the changes introduced in this PR require language features only available in Python 3.10 and later.