### PR TITLE
Add Python 3.13 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ jobs:
           python.version: '3.11'
         Python312:
           python.version: '3.12'
+        Python313:
+          python.version: '3.13'
     steps:
       - task: UsePythonVersion@0
         inputs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,13 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development :: Libraries',
     'Typing :: Typed'
 ]
 
-requires-python=">=3.8"
+requires-python=">=3.10"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]


### PR DESCRIPTION
Changes:
- Build project with Python 3.13 in CI pipeline 
- Add Python 3.13 as supported language version to package metadata